### PR TITLE
Replaced call to split (deprecated since php 5.3.0) to preg_split.

### DIFF
--- a/web/pierc_db.php
+++ b/web/pierc_db.php
@@ -192,7 +192,7 @@ class pierc_db extends db_class
 		$offset = (int) $offset;
 		
 		$searchquery = " WHERE ";
-		$searcharray = split("[ |]", $search);
+		$searcharray = preg_split("[ |]", $search);
 		foreach($searcharray as $searchterm )
 		{
 			$searchquery .= "(message LIKE '%".


### PR DESCRIPTION
Hi, on our server, any search results in a big wall of php errors because split is deprecated. Here's a fix.

This is my first time using git/github so I hope I'm doing things right. 

Cheers :)
