### PR TITLE
preg_split, unlike split, takes a pattern with slashes.

### DIFF
--- a/web/pierc_db.php
+++ b/web/pierc_db.php
@@ -192,7 +192,7 @@ class pierc_db extends db_class
 		$offset = (int) $offset;
 		
 		$searchquery = " WHERE ";
-		$searcharray = preg_split("[ |]", $search);
+		$searcharray = preg_split("/[ |]/", $search);
 		foreach($searcharray as $searchterm )
 		{
 			$searchquery .= "(message LIKE '%".


### PR DESCRIPTION
My pull request from yesterday broke search (it wasn't even subtle, don't know how I missed that). Sorry
