### PR TITLE
Change the Docs to accommodate for the different CharSet for Table

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@ Your MySQL connection id is 5340 to server version: 3.23.54
 
 Type 'help;' or '\h' for help. Type '\c' to clear the buffer.
 
-mysql&gt; CREATE DATABASE pierc;
+mysql&gt; CREATE DATABASE pierc CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
 Query OK, 1 row affected (0.00 sec)
 
 mysql&gt; GRANT ALL PRIVILEGES ON pierc.* TO "pierc_user"@"hostname"


### PR DESCRIPTION
Part 1 / 2 : 

Change the Docs to accommodate for the different CharSet for Table
I experienced some issues with UTF8 char storage - 
So I read around and found this : https://stackoverflow.com/questions/6769901/why-is-mysqls-default-collation-latin1-swedish-ci
This changes the Charset from being latin1_swedish_ci ( Depending on what Version Of SQL you run, to being explicitly utf8 )

I think this may also address the issue "Text encoding failure #36"

I will look at the Bot Code next.